### PR TITLE
Die Klasse "Ding" von einem Interface ableiten

### DIFF
--- a/NESW_Textadventure/Ding.cs
+++ b/NESW_Textadventure/Ding.cs
@@ -3,16 +3,34 @@ using TextAdventure;
 
 namespace TextAdventure
 {
-	public class Ding
+	// Interface
+	// Jedes Ding muss einen Namen besitzen
+	interface IDing
 	{
-		// Test
+		string name
+		{
+			get;
+			set;
+		}
+	}
+	
+	public class Ding : IDing
+	{
 		// -- Properties, die alle Dinge haben sollen
 		// Der Name eines Dings
-		public string name = "untitled item";
+		// Die Variable ist privat und kann nur ueber die vom Interface definierte Eigenschaft
+		// "name" gelesen werden
+		private string privateName = "untitled item";
 
 		public Ding ( string in_name )
 		{
-			name = in_name;
+			privateName = in_name;
+		}
+		
+		public string name
+		{
+			get { return privateName; }
+			set { privateName = value; }
 		}
 	}
 }

--- a/NESW_Textadventure/Ding.cs
+++ b/NESW_Textadventure/Ding.cs
@@ -5,6 +5,7 @@ namespace TextAdventure
 {
 	public class Ding
 	{
+		// Test
 		// -- Properties, die alle Dinge haben sollen
 		// Der Name eines Dings
 		public string name = "untitled item";

--- a/NESW_Textadventure/Ort.cs
+++ b/NESW_Textadventure/Ort.cs
@@ -25,8 +25,8 @@ namespace TextAdventure
 
 		// Property für die Dinge, die in diesem Raum
 		// sind
-		Dictionary<string, Ding> dinge =
-			new Dictionary<string, Ding>();
+		Dictionary<string, IDing> dinge =
+			new Dictionary<string, IDing>();
 		
 
 		// -- Konstruktor des allgemeinen Ortes ohne Parameter


### PR DESCRIPTION
Ich bin mir nicht sicher inwiefern Polimorphie bei Klassen funktioniert.
Das eigentliche Inventar in "Ort.cs" (dinge) ist ein Directory mit Ding-Objekten. Das Ding-Objekt bezieht sich hierbei aber nur auf die Elternklasse von allen von uns abgeleitenen eigenen Dingen. Damit hätten wir vom Inventar aus nur Zugriff auf den Namen des Dings, da dies die einzige Variable ist, welche in der Elternklasse definiert ist.

Besser wäre es vielleicht, wenn wir die Ding Klasse von einem Interface ableiten, um vollumfänglichen Zugriff auf unsere eigenen erstellten Dinge zu ermöglichen. Das Inventar wäre dabei ein Directory aus Ding-Interfaces.

Andererseits wäre diese Änderung natürlich nicht nötig, wenn wir das Directory mit den Dingen nur dazu brauchen, um die Namen aller Dinge im Raum aufzulisten.
